### PR TITLE
适配版本 3.8.0

### DIFF
--- a/footer.ftl
+++ b/footer.ftl
@@ -8,7 +8,7 @@
   </div>
 </footer>
 <script type="text/javascript" src="${staticServePath}/js/lib/jquery/jquery.min.js" charset="utf-8"></script>
-<script type="text/javascript" src="${staticServePath}/js/common${miniPostfix}.js?${staticResourceVersion}" charset="utf-8"></script>
-<script type="text/javascript" src="${staticServePath}/skins/${skinDirName}/js/common${miniPostfix}.js?${staticResourceVersion}" charset="utf-8"></script>
+<script type="text/javascript" src="${staticServePath}/js/common.min.js?${staticResourceVersion}" charset="utf-8"></script>
+<script type="text/javascript" src="${staticServePath}/skins/${skinDirName}/js/common.min.js?${staticResourceVersion}" charset="utf-8"></script>
 <#include "../../common-template/label.ftl">
 ${plugins}

--- a/side.ftl
+++ b/side.ftl
@@ -21,6 +21,7 @@
       <img class="user__avatar" src="${adminUser.userAvatar}" alt="${adminUser.userName}"/>
       <div class="user__info">
         <div class="item"><a href="${servePath}/archives.html">${statistic.statisticPublishedBlogArticleCount}<span class="text">${articleLabel}</span></a></div>
+        <div class="item"><span data-uvstaturl="${servePath}">${statistic.statisticBlogViewCount}</span><span class="text">${viewLabel}</span></div>
         <div class="item">${onlineVisitorCnt}<span class="text">${onlineVisitorLabel}</span></div>
       </div>
     </main>


### PR DESCRIPTION
1. 皮肤报错原因是 3.8.0 版本 miniPostfix 变量不可用，参考 [9IPHP](https://github.com/88250/solo/blob/master/src/main/resources/skins/9IPHP/footer.ftl) 皮肤做如下的修改
2. 参考 [9IPHP](https://github.com/88250/solo/blob/master/src/main/resources/skins/9IPHP/side.ftl) 皮肤增加了浏览量计数